### PR TITLE
feat: make available string values collapsible

### DIFF
--- a/src/components/ui/FunctionParameters.tsx
+++ b/src/components/ui/FunctionParameters.tsx
@@ -62,12 +62,32 @@ export const FunctionParameters: FC<FunctionParametersProps> = ({
 						<HtmlContent html={param.details} />
 					</div>
 
+					{param.default && (
+						<p class="mt-3 text-sm">
+							<span class="font-medium">
+								<Translation translationKey="defaultValue" />
+							</span>{" "}
+							<span class="text-gray-700">
+								<HtmlContent html={param.default} />
+							</span>
+						</p>
+					)}
+
+					{/* Put all collapsible blocks after non-collapsible blocks. */}
+
 					{param.strings.length > 0 && (
-						<div class="mt-3">
-							<h5 class="text-sm font-medium text-gray-700 mb-2">
+						<details
+							class="my-4 folding-example group"
+							// The list of strings can be very long. For example, `page.paper` has 100+ possibilities.
+							open={param.strings.length <= 5}
+						>
+							<summary class="flex items-center gap-1 text-sm font-medium text-blue-600 cursor-pointer hover:text-blue-800">
+								<div class="w-4 h-4 text-gray-400 transform transition-transform duration-200 group-open:rotate-90">
+									<ChevronRightIcon />
+								</div>
 								<Translation translationKey="stringValues" />
-							</h5>
-							<ul class="type-args space-y-2 pl-4">
+							</summary>
+							<ul class="type-args space-y-2">
 								{param.strings.map((string) => (
 									<li key={string.string}>
 										<div class="break-box">
@@ -81,22 +101,11 @@ export const FunctionParameters: FC<FunctionParametersProps> = ({
 									</li>
 								))}
 							</ul>
-						</div>
-					)}
-
-					{param.default && (
-						<p class="mt-3 text-sm">
-							<span class="font-medium">
-								<Translation translationKey="defaultValue" />
-							</span>{" "}
-							<span class="text-gray-700">
-								<HtmlContent html={param.default} />
-							</span>
-						</p>
+						</details>
 					)}
 
 					{param.example && (
-						<details class="mt-4 folding-example group">
+						<details class="my-4 folding-example group">
 							<summary class="flex items-center gap-1 text-sm font-medium text-blue-600 cursor-pointer hover:text-blue-800">
 								<div class="w-4 h-4 text-gray-400 transform transition-transform duration-200 group-open:rotate-90">
 									<ChevronRightIcon />

--- a/src/translation/en-US.tsx
+++ b/src/translation/en-US.tsx
@@ -54,7 +54,7 @@ export const Translation: TranslationComponent = (props) => {
 		case "defaultValue":
 			return <Fragment>Default value:</Fragment>;
 		case "stringValues":
-			return <Fragment>Available string values:</Fragment>;
+			return <Fragment>Available string values</Fragment>;
 		case "showExample":
 			return <Fragment>Show example</Fragment>;
 		case "tableOfContents":

--- a/src/translation/ja-JP.tsx
+++ b/src/translation/ja-JP.tsx
@@ -59,7 +59,7 @@ export const Translation: TranslationComponent = (props) => {
 		case "defaultValue":
 			return <Fragment>デフォルト値：</Fragment>;
 		case "stringValues":
-			return <Fragment>使用可能な文字列値：</Fragment>;
+			return <Fragment>使用可能な文字列値</Fragment>;
 		case "showExample":
 			return <Fragment>例を表示</Fragment>;
 		case "tableOfContents":


### PR DESCRIPTION
Resolves #3

Examples:

- `page.paper`: [official](https://typst.app/docs/reference/layout/page/#parameters-paper), [jp](https://typst-jp.github.io/docs/reference/layout/page/#parameters-paper)
- `eval.mode`: [official](https://typst.app/docs/reference/foundations/eval/#parameters-mode), [jp](https://typst-jp.github.io/docs/reference/foundations/eval/#parameters-mode)
- `bibliography.style`: [official](https://typst.app/docs/reference/model/bibliography/#parameters-style), [jp](https://typst-jp.github.io/docs/reference/model/bibliography/#parameters-style)

<details>
<summary>All parameters with nonempty strings</summary>

```bash
$ jq '.. | select(type == "object" and has("strings") and (.strings | type == "array" and length > 1)) | .name' public/docs.json --raw-output | sort | uniq
aria-autocomplete
aria-current
aria-haspopup
aria-invalid
aria-live
aria-orientation
aria-relevant
aria-sort
as
autocapitalize
autocomplete
bottom-edge
cap
class
colorspace
command
crossorigin
dash
decoding
enctype
endian
enterkeyhint
fetchpriority
fill-rule
fit
form
format
formenctype
formmethod
formtarget
http-equiv
inputmode
join
kind
linebreaks
loading
method
mode
name
number-type
number-width
numbering-scope
paper
popovertargetaction
referrerpolicy
rel
relationship
relative
role
sandbox
scaling
scope
shadowrootmode
shape
style
target
to
top-edge
type
weight
wrap
```

</details>

<details>
<summary>Number of possible values for each parameter</summary>

```nu
jq '[.. | select(type == "object" and has("strings") and (.strings | type == "array" and length > 1)) | { name: .name, n_strings: .strings | length }]' public/docs.json | from json | sort-by n_strings | uniq | to csv
```

```csv
name,n_strings
endian,2
scope,2
linebreaks,2
numbering-scope,2
form,2
number-type,2
number-width,2
to,2
fill-rule,2
mode,2
relative,2
scaling,2
aria-invalid,2
crossorigin,2
loading,2
decoding,2
fetchpriority,2
colorspace,2
shadowrootmode,2
wrap,2
mode,3
bottom-edge,3
style,3
fit,3
cap,3
join,3
aria-autocomplete,3
aria-live,3
aria-orientation,3
aria-sort,3
autocapitalize,3
formenctype,3
formmethod,3
popovertargetaction,3
type,3
enctype,3
method,3
form,4
relationship,4
target,4
shape,4
formtarget,4
name,4
scope,4
form,5
top-edge,5
aria-current,5
aria-haspopup,5
aria-relevant,5
http-equiv,5
type,5
kind,5
format,6
command,6
enterkeyhint,7
inputmode,7
referrerpolicy,8
weight,9
class,10
dash,10
sandbox,13
type,22
as,22
rel,27
autocomplete,61
role,80
style,86
paper,107
```

</details>

---

We need a PR preview bot. Netlify offers a free one, even for org accounts. See https://github.com/typst-doc-cn/clreq/pull/49 for an example.