### PR TITLE
fix: hide definitions on category pages when there are no items

### DIFF
--- a/src/components/templates/CategoryTemplate.tsx
+++ b/src/components/templates/CategoryTemplate.tsx
@@ -27,21 +27,25 @@ export const CategoryTemplate: FC<CategoryTemplateProps> = ({
 		>
 			<h1 id="summary">{page.body.content.title}</h1>
 			<HtmlContent html={page.body.content.details} />
-			<h2 id="definitions">
-				<Translation translationKey="definition" />
-			</h2>
-			<ul class="subgridded">
-				{page.body.content.items.map((item) => (
-					<li key={item.route}>
-						<div>
-							<a href={item.route}>
-								{item.code ? <code>{item.name}</code> : item.name}
-							</a>
-						</div>
-						<div class="pl-4">{item.oneliner}</div>
-					</li>
-				))}
-			</ul>
+			{page.body.content.items.length > 0 && (
+				<>
+					<h2 id="definitions">
+						<Translation translationKey="definition" />
+					</h2>
+					<ul class="subgridded">
+						{page.body.content.items.map((item) => (
+							<li key={item.route}>
+								<div>
+									<a href={item.route}>
+										{item.code ? <code>{item.name}</code> : item.name}
+									</a>
+								</div>
+								<div class="pl-4">{item.oneliner}</div>
+							</li>
+						))}
+					</ul>
+				</>
+			)}
 		</BaseTemplate>
 	);
 };


### PR DESCRIPTION
close https://github.com/typst-jp/docs/issues/327