### PR TITLE
feat: add Typst-style markup heading decorations

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -36,7 +36,8 @@
 }
 
 body {
-	font-family: "HK Grotesk", Inter, "BIZ UDGothic", "BIZ UDPGothic", system-ui,
+	font-family:
+		"HK Grotesk", Inter, "BIZ UDGothic", "BIZ UDPGothic", system-ui,
 		-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
 		Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 }
@@ -45,8 +46,9 @@ code,
 pre,
 kbd,
 samp {
-	font-family: "Cascadia Mono", SFMono-Regular, Menlo, Monaco, Consolas,
-		"Liberation Mono", "Courier New", monospace;
+	font-family:
+		"Cascadia Mono", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+		"Courier New", monospace;
 }
 
 /* Information box */
@@ -95,34 +97,29 @@ Typst-style markup heading decorations
 
 Top-level heading indicates a top-level section of the document rather than its title.
 */
+.prose h2::before,
+.prose h3::before,
+.prose h4::before,
+.prose h5::before,
+.prose h6::before {
+	@apply text-gray-400;
+	margin-right: 1ch;
+}
+
 .prose h2::before {
 	content: "=";
-	@apply text-gray-400;
-	margin-right: 1ch;
 }
-
 .prose h3::before {
 	content: "==";
-	@apply text-gray-400;
-	margin-right: 1ch;
 }
-
 .prose h4::before {
 	content: "===";
-	@apply text-gray-400;
-	margin-right: 1ch;
 }
-
 .prose h5::before {
 	content: "====";
-	@apply text-gray-400;
-	margin-right: 1ch;
 }
-
 .prose h6::before {
 	content: "=====";
-	@apply text-gray-400;
-	margin-right: 1ch;
 }
 
 /*


### PR DESCRIPTION
This pull request adds Typst-style markup decorations to the header.

Although it's outside the scope of this PR, applying this change will cause the existing Reference pages to look a bit odd, so a separate fix will be needed for that.

![](https://github.com/user-attachments/assets/baee4a87-0f71-4922-a4da-34dcfbc0def0)
