### PR TITLE
fix: refine info box styles

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -53,20 +53,12 @@ samp {
 
 /* Information box */
 .info-box {
-	@apply my-8 rounded-md border border-cyan-200 bg-cyan-50 overflow-hidden relative;
-}
-
-.info-box > * {
-	@apply px-6;
+	@apply my-8 rounded-md border border-cyan-200 bg-cyan-50 overflow-hidden relative pt-8 pb-4 px-6;
 }
 
 .info-box::before {
 	content: "💡";
 	@apply absolute top-0 left-0 bg-cyan-200 text-cyan-800 text-xs font-bold py-1 px-3 rounded-br;
-}
-
-.info-box > *:first-child {
-	@apply pt-4;
 }
 
 /* Hide elements with the x-cloak attribute from Alpine.js */


### PR DESCRIPTION

## Before

<img width="1280" height="1769" alt="image" src="https://github.com/user-attachments/assets/dfe08b59-d228-4384-ad3f-8c6d5b6b7bb2" />

## After

<img width="1280" height="1801" alt="image" src="https://github.com/user-attachments/assets/cbed5d58-c8d5-41f3-a906-cb5fda77204c" />
