### PR TITLE
feat: add footnote styles

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -213,3 +213,12 @@ pre {
 	background: #f6f8fa !important;
 	color: #1f2328;
 }
+
+/* Footnote styles */
+.prose .footnote-definition {
+	@apply flex items-baseline gap-2 mt-6 pt-4 border-t border-gray-200 text-sm;
+}
+
+.prose .footnote-definition p {
+	@apply m-0;
+}


### PR DESCRIPTION
close #37

This pull request adds CSS styles to the footnote definitions and their paragraphs.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/db05c7f4-c768-400f-94ce-5276da57e1b2" />
