### PR TITLE
fix: remove focus ring color from tooltip button styles

### DIFF
--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -110,7 +110,7 @@ export const Tooltip: FC<TooltipProps> = ({ kind }) => {
 
 			<button
 				type="button"
-				class="w-4 h-4 hover:bg-black/10 rounded focus:outline-none cursor-pointer"
+				class="w-4 h-4 hover:bg-black/10 rounded cursor-pointer"
 				aria-label={translation.showInformation({
 					name: translation.tooltipKind({ kind }),
 				})}


### PR DESCRIPTION
Just a nitpick, but I fixed a design inconsistency on the Tooltip button.