### PR TITLE
fix: change color type icon bg to 4-color gradient

### DIFF
--- a/src/components/ui/TypeIcon.tsx
+++ b/src/components/ui/TypeIcon.tsx
@@ -39,7 +39,9 @@ const getTypeStyles = (
 			label: { bgColor: "bg-blue-100", textColor: "text-blue-800" },
 
 			color: {
-				bgColor: "bg-gradient-to-r from-blue-300 via-green-200 to-yellow-200",
+				// blue-300, green-200, yellow-200, red-300
+				bgColor:
+					"bg-[linear-gradient(to_right,#93c5fd,#bbf7d0,#fef08a,#fca5a5)]",
 				textColor: "text-gray-800",
 			},
 		};


### PR DESCRIPTION
Just a nitpick, but the gradient in the background for color type ended with yellow. It looked a bit odd.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/3676a429-8240-4475-a2a5-76545673e739" />
