### PR TITLE
fix: add background color for preview-only examples

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -93,8 +93,14 @@ samp {
 	@apply flex-1 m-0 rounded-none whitespace-pre overflow-x-auto lg:flex-[1_0_auto];
 }
 
-.previewed-code .preview {
-	@apply flex-1 flex-wrap bg-gray-200 flex items-center justify-center p-4 lg:min-w-1/2;
+.preview {
+	/* Preview-only examples are not wrapped in `.preview-code`, but they also need styles to make borders visible */
+	@apply bg-gray-200 p-4;
+
+	/* Side-by-side examples need additional styles for preview images. */
+	.previewed-code & {
+		@apply flex-1 flex-wrap flex items-center justify-center lg:min-w-1/2;
+	}
 }
 
 .previewed-code .preview img {

--- a/src/globals.css
+++ b/src/globals.css
@@ -94,7 +94,7 @@ samp {
 }
 
 .preview {
-	/* Preview-only examples are not wrapped in `.preview-code`, but they also need styles to make borders visible */
+	/* Preview-only examples are not wrapped in `.previewed-code`, but they also need styles to make borders visible */
 	@apply bg-gray-200 p-4;
 
 	/* Side-by-side examples need additional styles for preview images. */


### PR DESCRIPTION
Page borders are crucial in some examples, but they are invisible without `@apply bg-gray-200 p-4`.

The new example for `page.footer-descent` is an instance. To test it, you can download the corresponding `docs.json` from [`docs-main.2026-03-10.530c127` - GitHub Actions - Typst dev builds](https://github.com/typst-community/dev-builds/actions/runs/22940205155).

[Before](https://ydx-typst.netlify.app/reference/layout/page/#parameters-footer-descent):
<img width="300" alt="图片" src="https://github.com/user-attachments/assets/d6d00b7c-1261-4b3d-8582-2a99b4e23d92" />

After:

<img width="300" alt="图片" src="https://github.com/user-attachments/assets/0d70ea72-c6b6-4820-8f9e-31e6543cdf46" />

